### PR TITLE
Add UCP.tools validator to Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of awesome Universal Commerce Protocol (UCP) resources, tools, an
 
 - 🎖️🐍📇 [UCP Samples](https://github.com/Universal-Commerce-Protocol/samples) - Sample implementations including Python and Node.js merchant servers and client scripts
 - [UCP Demo Playground](https://ucp-demo.web.app) - Community-created playground demo built using Google's guide
+- [UCP.tools](https://ucptools.dev) - Free UCP profile validator and generator. Checks Schema.org compliance, product feed quality, and AI commerce readiness.
 
 <br>
 


### PR DESCRIPTION
Hey! 👋

Adding UCP.tools to the Developer Tools section - it's a free validator for UCP profiles that I've been using to check merchant readiness.

What it does:
- Validates /.well-known/ucp.json profiles
- Checks Schema.org requirements (MerchantReturnPolicy, shippingDetails)
- Analyzes product feed quality for AI agent visibility
- Gives an A-F readiness score

No signup needed, works on any domain.

Site: https://ucptools.dev

Let me know if you'd prefer it in a different section or want me to tweak the description.