### PR TITLE
Add Fidacy Trust-Verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of awesome Universal Commerce Protocol (UCP) resources, tools, an
 - [UCP Demo Playground](https://ucp-demo.web.app) - Community-created playground demo built using Google's guide
 - ✅ [UCP Lighthouse](https://ucp.rest) - Validate UCP & Community payloads. The ultimate OpenAI / ChatGPT Agentic Commerce schema validator to ensure your products are ready for the AI era.
 - ☁️🛠️ [UCP Doctor](https://doctor.awesomeucp.com) - Diagnostic tool for validating Universal Commerce Protocol implementations
+- 🛡️ [Fidacy Trust-Verdict](https://fidacy.com/ucp/extensions/trust-verdict/v1) - Neutral, independently verifiable trust verdict (approve/review/deny) for agent payments. Rides UCP's `signals` as `com.fidacy.trust_verdict`; verify offline with the open-source [@fidacy/verify](https://www.npmjs.com/package/@fidacy/verify).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ A curated list of awesome Universal Commerce Protocol (UCP) resources, tools, an
 
 ## Developer Tools
 
+- 🛡️ [Fidacy Trust-Verdict](https://fidacy.com/ucp/extensions/trust-verdict/v1) - Neutral, independently verifiable trust verdict (approve/review/deny) for agent payments. Rides UCP's `signals` as `com.fidacy.trust_verdict`; verify offline with the open-source [@fidacy/verify](https://www.npmjs.com/package/@fidacy/verify).
 - 🤖 [UCP.tools](https://ucptools.dev) - Free UCP profile validator and generator. Checks Schema.org compliance, product feed quality, and AI commerce readiness.
 - ☁️🛠️ [UCP Checker](https://ucpchecker.com) - The unofficial industry-standard validator. Lints live UCP manifests for schema compliance, tests API latency, and generates "verified" badges for repositories.
 - 🎖️🐍📇 [UCP Samples](https://github.com/Universal-Commerce-Protocol/samples) - Sample implementations including Python and Node.js merchant servers and client scripts
 - [UCP Demo Playground](https://ucp-demo.web.app) - Community-created playground demo built using Google's guide
 - ✅ [UCP Lighthouse](https://ucp.rest) - Validate UCP & Community payloads. The ultimate OpenAI / ChatGPT Agentic Commerce schema validator to ensure your products are ready for the AI era.
 - ☁️🛠️ [UCP Doctor](https://doctor.awesomeucp.com) - Diagnostic tool for validating Universal Commerce Protocol implementations
-- 🛡️ [Fidacy Trust-Verdict](https://fidacy.com/ucp/extensions/trust-verdict/v1) - Neutral, independently verifiable trust verdict (approve/review/deny) for agent payments. Rides UCP's `signals` as `com.fidacy.trust_verdict`; verify offline with the open-source [@fidacy/verify](https://www.npmjs.com/package/@fidacy/verify).
 
 <br>
 


### PR DESCRIPTION
Adds **Fidacy Trust-Verdict** under Developer Tools: a neutral, independently verifiable trust verdict (approve/review/deny) for agent payments. It rides UCP's `signals` mechanism as `com.fidacy.trust_verdict` (the schema's slot for verifiable third-party attestations); the signed EdDSA JWS is verifiable offline with the open-source @fidacy/verify, no trust in the issuer required.

- Binding spec + URI: https://fidacy.com/ucp/extensions/trust-verdict/v1
- Verifier: https://www.npmjs.com/package/@fidacy/verify
- Apache-2.0